### PR TITLE
[SYNC-5] fix: Fix the issue of deleting block without changing conten…

### DIFF
--- a/src/controllers/article_controller.js
+++ b/src/controllers/article_controller.js
@@ -596,6 +596,20 @@ module.exports = {
               checkIfChange = true
             }
           }
+          for (const block of detectArticle.blocks) {
+            let blockDeleted = true
+            for (const compareblock of updateObj.blocks) {
+              if (block._id.toString() === compareblock._id.toString()) {
+                blockDeleted = false
+                break
+              }
+            }
+            if (blockDeleted) {
+              console.log('block has been deleted')
+              checkIfChange = true
+              break
+            }
+          }
         }
 
         console.log(`The article has ${checkIfChange ? '' : 'not'} changed`)


### PR DESCRIPTION
## Description: The article can now be updated when people only delete blocks without doing other changes
-
## Changes: Fix the issue of deleting block without changing content can't update articles
-
## Test Scope: 
-
## Screenshots (optional)