### PR TITLE
[SYNC-176][BE] Added a new field 'timeEnable' in article block

### DIFF
--- a/src/models/article.js
+++ b/src/models/article.js
@@ -13,6 +13,9 @@ const blockSchema = new mongoose.Schema({
     type: Date,
     required: true
   },
+  timeEnable: {
+    type: Boolean
+  },
   content: {
     type: Object
   },


### PR DESCRIPTION
## Description: 
- The *detailed time* is optional for each block in an article, and since datetime information is saved using a Date() format, we add a `timeEnable` field to distinguish whether or not to display time details in the front-end.
## Changes:
- In article.js, we add a `timeEnable` boolean to the block schema.